### PR TITLE
Image Reply Crash Fix

### DIFF
--- a/app/src/main/java/com/clover/studio/spikamessenger/ui/main/chat/ChatMessagesFragment.kt
+++ b/app/src/main/java/com/clover/studio/spikamessenger/ui/main/chat/ChatMessagesFragment.kt
@@ -52,7 +52,6 @@ import com.clover.studio.spikamessenger.data.models.entity.MessageRecords
 import com.clover.studio.spikamessenger.data.models.entity.User
 import com.clover.studio.spikamessenger.data.models.junction.RoomWithUsers
 import com.clover.studio.spikamessenger.databinding.FragmentChatMessagesBinding
-import com.clover.studio.spikamessenger.ui.ImageSelectedContainer
 import com.clover.studio.spikamessenger.ui.ReactionContainer
 import com.clover.studio.spikamessenger.ui.ReactionsContainer
 import com.clover.studio.spikamessenger.utils.Const
@@ -374,6 +373,8 @@ class ChatMessagesFragment : BaseFragment(), ChatOnBackPressed {
             }
             bindingSetup.etMessage.setText("")
             hideSendButton()
+            bottomSheetReplyAction.state = BottomSheetBehavior.STATE_COLLAPSED
+            bindingSetup.clBottomReplyAction.visibility = View.GONE
         }
 
         bindingSetup.tvUnblock.setOnClickListener {
@@ -932,6 +933,7 @@ class ChatMessagesFragment : BaseFragment(), ChatOnBackPressed {
                             Const.UserActions.NAVIGATE_TO_MEDIA_FRAGMENT -> handleMediaNavigation(
                                 message
                             )
+
                             else -> Timber.d("No other action currently")
                         }
                     }
@@ -1436,8 +1438,6 @@ class ChatMessagesFragment : BaseFragment(), ChatOnBackPressed {
             endToStart = bindingSetup.ivCamera.id
         }
         bindingSetup.ivAdd.rotation = ROTATION_OFF
-        bottomSheetReplyAction.state = BottomSheetBehavior.STATE_COLLAPSED
-        bindingSetup.clBottomReplyAction.visibility = View.GONE
     }
 
     private fun showDeleteMessageDialog(message: Message) {

--- a/app/src/main/java/com/clover/studio/spikamessenger/utils/helpers/ChatAdapterHelper.kt
+++ b/app/src/main/java/com/clover/studio/spikamessenger/utils/helpers/ChatAdapterHelper.kt
@@ -15,7 +15,6 @@ import androidx.core.content.res.ResourcesCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
-import com.bumptech.glide.request.target.Target
 import com.clover.studio.spikamessenger.R
 import com.clover.studio.spikamessenger.data.models.entity.MessageAndRecords
 import com.clover.studio.spikamessenger.data.models.entity.MessageRecords
@@ -184,7 +183,7 @@ object ChatAdapterHelper {
         }
 
         tvUsername.text =
-            users.firstOrNull { it.id == chatMessage.message.body.referenceMessage?.fromUserId }!!.formattedDisplayName
+            users.firstOrNull { it.id == chatMessage.message.body.referenceMessage?.fromUserId }?.formattedDisplayName
 
         when (chatMessage.message.body.referenceMessage?.type) {
             /**Image or video type*/


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant
motivation and context. List any dependencies that are required for this change.

Fixed issue where you could reply to a message with an image in some special cases. Removed the option to do that and handled case if something like that happened.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration. All testing was done
manually by following, plainly, functionality requirements. If there are some special edge cases or
special ways that things need to be tested they will be mentioned below.

**Test Configuration**:

* Firmware version: G980FXXSFFVHA
* Hardware: SAMSUNG Galaxy S20
* SDK: Android 13

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
