### PR TITLE
Retain Bottom Sheet on App Resume

### DIFF
--- a/app/src/main/java/com/clover/studio/spikamessenger/ui/main/chat/ChatMessagesFragment.kt
+++ b/app/src/main/java/com/clover/studio/spikamessenger/ui/main/chat/ChatMessagesFragment.kt
@@ -1742,16 +1742,6 @@ class ChatMessagesFragment : BaseFragment(), ChatOnBackPressed {
 
     override fun onResume() {
         super.onResume()
-//        for (bottomSheet in bottomSheets) {
-//            bottomSheet.state = BottomSheetBehavior.STATE_COLLAPSED
-//        }
-
-//        bindingSetup.clBottomMessageActions.visibility = View.GONE
-//        bindingSetup.clBottomSheet.visibility = View.GONE
-//        bindingSetup.clDetailsAction.visibility = View.GONE
-//        bindingSetup.clBottomReplyAction.visibility = View.GONE
-//        bindingSetup.clReactionsDetails.visibility = View.GONE
-
         viewModel.getBlockedUsersList()
     }
 

--- a/app/src/main/java/com/clover/studio/spikamessenger/ui/main/chat/ChatMessagesFragment.kt
+++ b/app/src/main/java/com/clover/studio/spikamessenger/ui/main/chat/ChatMessagesFragment.kt
@@ -1742,15 +1742,15 @@ class ChatMessagesFragment : BaseFragment(), ChatOnBackPressed {
 
     override fun onResume() {
         super.onResume()
-        for (bottomSheet in bottomSheets) {
-            bottomSheet.state = BottomSheetBehavior.STATE_COLLAPSED
-        }
+//        for (bottomSheet in bottomSheets) {
+//            bottomSheet.state = BottomSheetBehavior.STATE_COLLAPSED
+//        }
 
-        bindingSetup.clBottomMessageActions.visibility = View.GONE
-        bindingSetup.clBottomSheet.visibility = View.GONE
-        bindingSetup.clDetailsAction.visibility = View.GONE
-        bindingSetup.clBottomReplyAction.visibility = View.GONE
-        bindingSetup.clReactionsDetails.visibility = View.GONE
+//        bindingSetup.clBottomMessageActions.visibility = View.GONE
+//        bindingSetup.clBottomSheet.visibility = View.GONE
+//        bindingSetup.clDetailsAction.visibility = View.GONE
+//        bindingSetup.clBottomReplyAction.visibility = View.GONE
+//        bindingSetup.clReactionsDetails.visibility = View.GONE
 
         viewModel.getBlockedUsersList()
     }


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant
motivation and context. List any dependencies that are required for this change.

Removed code that was hiding bottom sheet when the chat activity resumed from the background. The sheet will now display the last state it was in, when the user returns to the app.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration. All testing was done
manually by following, plainly, functionality requirements. If there are some special edge cases or
special ways that things need to be tested they will be mentioned below.

Dev testing

**Test Configuration**:

* Firmware version: G980FXXSFFVHA
* Hardware: SAMSUNG Galaxy S20
* SDK: Android 13

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
