### PR TITLE
Parcelable Crash

### DIFF
--- a/app/src/main/java/com/clover/studio/spikamessenger/ui/main/chat/ChatScreenActivity.kt
+++ b/app/src/main/java/com/clover/studio/spikamessenger/ui/main/chat/ChatScreenActivity.kt
@@ -76,7 +76,7 @@ class ChatScreenActivity : BaseActivity() {
 
         viewModel.searchMessageId.value = intent.getIntExtra(Const.Navigation.SEARCH_MESSAGE_ID, 0)
         viewModel.roomWithUsers.value =
-            intent.getParcelableExtra(Const.Navigation.ROOM_DATA, RoomWithUsers::class.java)
+            intent.getParcelableExtra(Const.Navigation.ROOM_DATA)
 
         Timber.d("Load check: ChatScreenActivity created")
 

--- a/app/src/main/java/com/clover/studio/spikamessenger/ui/main/chat/ChatScreenActivity.kt
+++ b/app/src/main/java/com/clover/studio/spikamessenger/ui/main/chat/ChatScreenActivity.kt
@@ -51,7 +51,6 @@ fun replaceChatScreenActivity(
 
 @AndroidEntryPoint
 class ChatScreenActivity : BaseActivity() {
-    var searchMessageId: Int? = 0
     var roomWithUsers: RoomWithUsers? = null
 
     private lateinit var bindingSetup: ActivityChatScreenBinding


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant
motivation and context. List any dependencies that are required for this change.

Fixed issue where parcelable method would crash apps on devices running versions lower than 33

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration. All testing was done
manually by following, plainly, functionality requirements. If there are some special edge cases or
special ways that things need to be tested they will be mentioned below.

Dev testing

**Test Configuration**:

* Firmware version: G980FXXSFFVHA
* Hardware: SAMSUNG Galaxy S20
* SDK: Android 13

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
