### PR TITLE
.MOV file crash fix

### DIFF
--- a/app/src/main/java/com/clover/studio/spikamessenger/ui/main/chat/ChatMessagesFragment.kt
+++ b/app/src/main/java/com/clover/studio/spikamessenger/ui/main/chat/ChatMessagesFragment.kt
@@ -1284,8 +1284,7 @@ class ChatMessagesFragment : BaseFragment() {
             val fileMimeType = getFileMimeType(context, uri)
             if ((fileMimeType?.contains(Const.JsonFields.IMAGE_TYPE) == true ||
                         fileMimeType?.contains(Const.JsonFields.VIDEO_TYPE) == true) &&
-                (!fileMimeType.contains(Const.JsonFields.SVG_TYPE) &&
-                        !fileMimeType.contains(Const.JsonFields.AVI_TYPE))
+                !Tools.forbiddenMimeTypes(fileMimeType)
             ) {
                 convertMedia(uri, fileMimeType)
             } else {

--- a/app/src/main/java/com/clover/studio/spikamessenger/utils/Const.kt
+++ b/app/src/main/java/com/clover/studio/spikamessenger/utils/Const.kt
@@ -108,6 +108,7 @@ class Const {
             const val IMAGE_TYPE = "image"
             const val SVG_TYPE = "svg"
             const val AVI_TYPE = "avi"
+            const val MOV_TYPE = "quicktime"
 
             // File upload
             const val CHUNK = "chunk"

--- a/app/src/main/java/com/clover/studio/spikamessenger/utils/Tools.kt
+++ b/app/src/main/java/com/clover/studio/spikamessenger/utils/Tools.kt
@@ -723,15 +723,21 @@ object Tools {
 
     fun getFileType(uri: Uri): String {
         val mimeType = getFileMimeType(MainApplication.appContext, uri)
-
         return when {
             mimeType?.contains(Const.JsonFields.SVG_TYPE) == true -> Const.JsonFields.FILE_TYPE
             mimeType?.contains(Const.JsonFields.AVI_TYPE) == true -> Const.JsonFields.FILE_TYPE
+            mimeType?.contains(Const.JsonFields.MOV_TYPE) == true -> Const.JsonFields.FILE_TYPE
             mimeType?.contains(Const.JsonFields.IMAGE_TYPE) == true -> Const.JsonFields.IMAGE_TYPE
             mimeType?.contains(Const.JsonFields.VIDEO_TYPE) == true -> Const.JsonFields.VIDEO_TYPE
             mimeType?.contains(Const.JsonFields.AUDIO_TYPE) == true -> Const.JsonFields.AUDIO_TYPE
             else -> Const.JsonFields.FILE_TYPE
         }
+    }
+
+    fun forbiddenMimeTypes(fileMimeType: String) : Boolean {
+        return (fileMimeType.contains(Const.JsonFields.SVG_TYPE) ||
+                fileMimeType.contains(Const.JsonFields.AVI_TYPE)) ||
+                fileMimeType.contains(Const.JsonFields.MOV_TYPE)
     }
 
     fun getFileMimeType(context: Context?, uri: Uri): String? {

--- a/app/src/main/java/com/clover/studio/spikamessenger/utils/UploadDownloadManager.kt
+++ b/app/src/main/java/com/clover/studio/spikamessenger/utils/UploadDownloadManager.kt
@@ -45,7 +45,7 @@ class UploadDownloadManager constructor(
         var mimeType = MainApplication.appContext.contentResolver.getType(fileData.fileUri)!!
         cancelUpload = false
 
-        if (mimeType.contains(Const.JsonFields.AVI_TYPE)) {
+        if (Tools.forbiddenMimeTypes(mimeType)) {
             mimeType = Const.JsonFields.FILE_TYPE
         }
 


### PR DESCRIPTION
# Description

Fixed sending MOV file crash. Added quicktime extension to the list of forbidden video extensions - those extensions will be sent as files.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Dev testing.

**Test Configuration**:

* Firmware version: G930FXXS7ETA1
* Hardware: Samsung galaxy s7
* SDK: Android 8, Oreo

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
