### PR TITLE
Retrofit Timeout and Error Context

### DIFF
--- a/app/src/main/java/com/clover/studio/spikamessenger/di/AppModule.kt
+++ b/app/src/main/java/com/clover/studio/spikamessenger/di/AppModule.kt
@@ -7,6 +7,7 @@ import com.clover.studio.spikamessenger.data.services.ChatService
 import com.clover.studio.spikamessenger.data.services.OnboardingService
 import com.clover.studio.spikamessenger.data.services.RetrofitService
 import com.clover.studio.spikamessenger.data.services.SSEService
+import com.clover.studio.spikamessenger.utils.Const
 import com.clover.studio.spikamessenger.utils.helpers.GsonProvider
 import com.google.gson.Gson
 import dagger.Module
@@ -41,8 +42,8 @@ object AppModule {
     @Provides
     fun provideRetrofitClient(interceptor: HttpLoggingInterceptor): OkHttpClient {
         return OkHttpClient.Builder()
-            .readTimeout(30, TimeUnit.SECONDS)
-            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(Const.Networking.TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .connectTimeout(Const.Networking.TIMEOUT_SECONDS, TimeUnit.SECONDS)
             .addInterceptor(interceptor)
             .build()
     }

--- a/app/src/main/java/com/clover/studio/spikamessenger/di/AppModule.kt
+++ b/app/src/main/java/com/clover/studio/spikamessenger/di/AppModule.kt
@@ -18,6 +18,7 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
 @Module
@@ -40,6 +41,8 @@ object AppModule {
     @Provides
     fun provideRetrofitClient(interceptor: HttpLoggingInterceptor): OkHttpClient {
         return OkHttpClient.Builder()
+            .readTimeout(30, TimeUnit.SECONDS)
+            .connectTimeout(30, TimeUnit.SECONDS)
             .addInterceptor(interceptor)
             .build()
     }

--- a/app/src/main/java/com/clover/studio/spikamessenger/ui/onboarding/number_registration/RegisterNumberFragment.kt
+++ b/app/src/main/java/com/clover/studio/spikamessenger/ui/onboarding/number_registration/RegisterNumberFragment.kt
@@ -115,7 +115,7 @@ class RegisterNumberFragment : BaseFragment() {
                 Resource.Status.ERROR -> {
                     DialogError.getInstance(requireContext(),
                         getString(R.string.registration_error),
-                        getString(R.string.registration_error_description),
+                        "${getString(R.string.registration_error_description)} \n\n ${it.message}",
                         null, getString(R.string.ok), object : DialogInteraction {
                             override fun onFirstOptionClicked() {
                                 // Ignore

--- a/app/src/main/java/com/clover/studio/spikamessenger/utils/Const.kt
+++ b/app/src/main/java/com/clover/studio/spikamessenger/utils/Const.kt
@@ -152,6 +152,8 @@ class Const {
 
     class Networking {
         companion object {
+            const val TIMEOUT_SECONDS: Long = 30
+
             // Sync Data
             const val API_SYNC_MESSAGES = "api/messenger/messages/sync/{lastUpdate}"
             const val API_SYNC_MESSAGE_RECORDS = "api/messenger/message-records/sync/{lastUpdate}"


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant
motivation and context. List any dependencies that are required for this change.

Added longer timeout timer for Retrofit calls, increased to 30 seconds. 

Added some context when registration fails, app will now also display the error message retrieved from the API.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration. All testing was done
manually by following, plainly, functionality requirements. If there are some special edge cases or
special ways that things need to be tested they will be mentioned below.

Dev testing

**Test Configuration**:

* Firmware version: G980FXXSFFVHA
* Hardware: SAMSUNG Galaxy S20
* SDK: Android 13

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

![JPEG_20231019_104339_67628494935566183](https://github.com/cloverstudio/SpikaAndroid/assets/50554253/1223114c-69e3-4608-975a-6b88f6ccd55e)

