### PR TITLE
Reaction Scrolling

### DIFF
--- a/app/src/main/java/com/clover/studio/spikamessenger/ui/main/chat/ChatMessagesFragment.kt
+++ b/app/src/main/java/com/clover/studio/spikamessenger/ui/main/chat/ChatMessagesFragment.kt
@@ -834,9 +834,9 @@ class ChatMessagesFragment : BaseFragment() {
 
     private fun setUpAdapterDataObserver() = with(bindingSetup) {
         val adapterDataObserver = object : RecyclerView.AdapterDataObserver() {
-            override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
+            override fun onItemRangeChanged(positionStart: Int, itemCount: Int) {
                 val scrollingIndex = positionStart + itemCount - 1
-                if (scrollingIndex >= 0 && chatAdapter.currentList.getOrNull(scrollingIndex)?.message?.fromUserId == localUserId) {
+                if (scrollingIndex >= 0) {
                     if (sendingScrollVisibility()) {
                         rvChat.smoothScrollToPosition(0)
                         scrollYDistance = 0


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant
motivation and context. List any dependencies that are required for this change.

Fixed scroll issue when adding reaction to last message in list. It should now scroll to the bottom when a reaction is added.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration. All testing was done
manually by following, plainly, functionality requirements. If there are some special edge cases or
special ways that things need to be tested they will be mentioned below.

Dev testing

**Test Configuration**:

* Firmware version:
* Hardware: SAMSUNG Galaxy S22
* SDK: Android 14

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
