### PR TITLE
Longpress Swipe Issue

### DIFF
--- a/app/src/main/java/com/clover/studio/spikamessenger/ui/main/chat/ChatMessagesFragment.kt
+++ b/app/src/main/java/com/clover/studio/spikamessenger/ui/main/chat/ChatMessagesFragment.kt
@@ -998,6 +998,8 @@ class ChatMessagesFragment : BaseFragment() {
             return
         }
 
+        itemTouchHelper?.attachToRecyclerView(null)
+
         hideKeyboard(root)
 
         val bottomSheet = ChatBottomSheet(msg.message, localUserId)
@@ -1108,6 +1110,10 @@ class ChatMessagesFragment : BaseFragment() {
                     requireActivity().supportFragmentManager,
                     ForwardBottomSheet.TAG
                 )
+            }
+
+            override fun sheetDismissed() {
+                updateSwipeController()
             }
         })
         bottomSheet.show(requireActivity().supportFragmentManager, ChatBottomSheet.TAG)

--- a/app/src/main/java/com/clover/studio/spikamessenger/ui/main/chat/bottom_sheets/ChatBottomSheet.kt
+++ b/app/src/main/java/com/clover/studio/spikamessenger/ui/main/chat/bottom_sheets/ChatBottomSheet.kt
@@ -1,5 +1,6 @@
 package com.clover.studio.spikamessenger.ui.main.chat.bottom_sheets
 
+import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -45,6 +46,7 @@ class ChatBottomSheet(
         fun actionAddCustomReaction()
         fun actionDownload()
         fun actionForward()
+        fun sheetDismissed()
     }
 
     fun setActionListener(listener: BottomSheetAction?) {
@@ -120,5 +122,10 @@ class ChatBottomSheet(
                 dismiss()
             }
         })
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        listener?.sheetDismissed()
     }
 }


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant
motivation and context. List any dependencies that are required for this change.

Fixed issue where you could swipe a message while message actions were open. Handled the item touch listener better.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration. All testing was done
manually by following, plainly, functionality requirements. If there are some special edge cases or
special ways that things need to be tested they will be mentioned below.

Dev testing

**Test Configuration**:

* Firmware version:
* Hardware: SAMSUNG Galaxy S22
* SDK: Android 14

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
