### PR TITLE
Video Container Fix

### DIFF
--- a/app/src/main/java/com/clover/studio/spikamessenger/ui/main/chat/ChatAdapter.kt
+++ b/app/src/main/java/com/clover/studio/spikamessenger/ui/main/chat/ChatAdapter.kt
@@ -33,6 +33,7 @@ import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.clover.studio.spikamessenger.R
 import com.clover.studio.spikamessenger.data.models.entity.Message
 import com.clover.studio.spikamessenger.data.models.entity.MessageAndRecords
+import com.clover.studio.spikamessenger.data.models.entity.MessageBody
 import com.clover.studio.spikamessenger.data.models.entity.User
 import com.clover.studio.spikamessenger.databinding.AudioLayoutBinding
 import com.clover.studio.spikamessenger.databinding.FileLayoutBinding
@@ -50,7 +51,6 @@ import com.clover.studio.spikamessenger.utils.helpers.ChatAdapterHelper.showHide
 import com.clover.studio.spikamessenger.utils.helpers.Resource
 import com.vanniktech.emoji.EmojiTextView
 import com.vanniktech.emoji.isOnlyEmojis
-import timber.log.Timber
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -721,10 +721,7 @@ class ChatAdapter(
         ivLoadingImage: ImageView,
         clContainer: ConstraintLayout
     ) {
-        val imageResized = Tools.resizeImage(
-            chatMessage.message.body?.file?.metaData?.width,
-            chatMessage.message.body?.file?.metaData?.height
-        )
+        val imageResized = handleMediaResize(chatMessage.message.body)
 
         val mediaPath = Tools.getMediaFile(context, chatMessage.message)
         loadMedia(
@@ -764,10 +761,7 @@ class ChatAdapter(
         ivLoadingImage: ImageView,
         clContainer: ConstraintLayout
     ) {
-        val imageResized = Tools.resizeImage(
-            chatMessage.message.body?.file?.metaData?.width,
-            chatMessage.message.body?.file?.metaData?.height
-        )
+        val imageResized = handleMediaResize(chatMessage.message.body)
 
         val mediaPath = Tools.getMediaFile(context, chatMessage.message)
         loadMedia(
@@ -837,10 +831,7 @@ class ChatAdapter(
                 tvVideoDuration.text = context.getString(R.string.audio_duration)
             }
 
-            val imageResized = Tools.resizeImage(
-                chatMessage.message.body?.file?.metaData?.width,
-                chatMessage.message.body?.file?.metaData?.height
-            )
+            val imageResized = handleMediaResize(chatMessage.message.body)
 
             val mediaPath = Tools.getMediaFile(context, chatMessage.message)
             loadMedia(
@@ -977,6 +968,22 @@ class ChatAdapter(
                 }
             })
         }
+    }
+
+    private fun handleMediaResize(body: MessageBody?): Pair<Int, Int> {
+        val imageResized: Pair<Int, Int> = if (body?.thumb != null) {
+            Tools.resizeImage(
+                body.thumb?.metaData?.width,
+                body.thumb?.metaData?.height
+            )
+        } else {
+            Tools.resizeImage(
+                body?.file?.metaData?.width,
+                body?.file?.metaData?.height
+            )
+        }
+
+        return imageResized
     }
 
     /** A method that sends a reaction to a message */

--- a/app/src/main/java/com/clover/studio/spikamessenger/ui/main/chat/ChatAdapter.kt
+++ b/app/src/main/java/com/clover/studio/spikamessenger/ui/main/chat/ChatAdapter.kt
@@ -971,7 +971,7 @@ class ChatAdapter(
     }
 
     private fun handleMediaResize(body: MessageBody?): Pair<Int, Int> {
-        val imageResized: Pair<Int, Int> = if (body?.thumb != null) {
+        val imageResized: Pair<Int, Int> = if (body?.thumb != null && body.thumb?.id != 0L) {
             Tools.resizeImage(
                 body.thumb?.metaData?.width,
                 body.thumb?.metaData?.height

--- a/app/src/main/java/com/clover/studio/spikamessenger/utils/Tools.kt
+++ b/app/src/main/java/com/clover/studio/spikamessenger/utils/Tools.kt
@@ -663,11 +663,17 @@ object Tools {
         var mediaPath = "$directory/${message.localId}.${Const.FileExtensions.JPG}"
         val file = File(mediaPath)
         if (!file.exists()) {
-            mediaPath = message.body?.thumb?.id?.let { imagePath ->
-                getFilePathUrl(
-                    imagePath
-                )
-            }.toString()
+            mediaPath = if (message.body?.thumb != null) {
+                message.body.thumb?.id?.let { imagePath ->
+                    getFilePathUrl(
+                        imagePath
+                    )
+                }.toString()
+            } else {
+                message.body?.fileId?.let { fileId ->
+                    getFilePathUrl(fileId)
+                }.toString()
+            }
         }
         return mediaPath
     }

--- a/app/src/main/res/layout/video_layout.xml
+++ b/app/src/main/res/layout/video_layout.xml
@@ -35,8 +35,8 @@
 
     <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/iv_video_thumbnail"
-        android:layout_width="@dimen/two_hundred_fifty_six_dp"
-        android:layout_height="@dimen/two_hundred_fifty_six_dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:adjustViewBounds="true"
         android:scaleType="centerCrop"
@@ -58,10 +58,10 @@
         android:textSize="@dimen/twelve_sp_text"
         android:visibility="visible" />
 
-    <View
-        android:layout_width="256dp"
-        android:layout_height="62dp"
-        android:layout_gravity="top"
-        android:background="@drawable/bg_shadow"/>
+<!--    <View-->
+<!--        android:layout_width="256dp"-->
+<!--        android:layout_height="62dp"-->
+<!--        android:layout_gravity="top"-->
+<!--        android:background="@drawable/bg_shadow"/>-->
 
 </FrameLayout>


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant
motivation and context. List any dependencies that are required for this change.

Fixed an issue where video container would be to wide when dealing with portrait videos. Also, changed how image resiting works and added some fallback if thumbnail is broken.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration. All testing was done
manually by following, plainly, functionality requirements. If there are some special edge cases or
special ways that things need to be tested they will be mentioned below.

Dev testing

**Test Configuration**:

* Firmware version:
* Hardware: SAMSUNG Galaxy S22
* SDK: Android 14

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

BEFORE: 
![JPEG_20240118_142946_848849399047877862](https://github.com/cloverstudio/SpikaAndroid/assets/50554253/4cb4e2e8-bf2e-4991-84c7-bc1926a177a3)

AFTER:
![JPEG_20240118_142946_7701187842140388256](https://github.com/cloverstudio/SpikaAndroid/assets/50554253/19d2c4bd-b26a-4bfc-bdd3-651920ae8939)
