### PR TITLE
Emoji size fix

### DIFF
--- a/app/src/main/java/com/clover/studio/spikamessenger/ui/main/chat/ChatAdapter.kt
+++ b/app/src/main/java/com/clover/studio/spikamessenger/ui/main/chat/ChatAdapter.kt
@@ -645,8 +645,9 @@ class ChatAdapter(
                 context,
                 if (sender) R.drawable.bg_message_send else R.drawable.bg_message_received
             )
+            Timber.d("Message: ${tvMessage.text}, size: ${tvMessage.getEmojiSize()} ")
+            tvMessage.setEmojiSize(0)
         }
-
         tvMessage.text = messageText
 
         tvMessage.apply {

--- a/app/src/main/java/com/clover/studio/spikamessenger/ui/main/chat/ChatAdapter.kt
+++ b/app/src/main/java/com/clover/studio/spikamessenger/ui/main/chat/ChatAdapter.kt
@@ -645,7 +645,6 @@ class ChatAdapter(
                 context,
                 if (sender) R.drawable.bg_message_send else R.drawable.bg_message_received
             )
-            Timber.d("Message: ${tvMessage.text}, size: ${tvMessage.getEmojiSize()} ")
             tvMessage.setEmojiSize(0)
         }
         tvMessage.text = messageText


### PR DESCRIPTION
# Description

Fixed emoji size on scroll. Everything is the same but on scroll we are setting the size of emojis to 0 (so they don't recycle by recycler view).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Dev testing.

**Test Configuration**:

* Firmware version: G930FXXS7ETA1
* Hardware: Samsung galaxy s7
* SDK: Android 8, Oreo

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
