### PR TITLE
Emoji search color fix

### DIFF
--- a/app/src/main/java/com/clover/studio/spikamessenger/utils/Tools.kt
+++ b/app/src/main/java/com/clover/studio/spikamessenger/utils/Tools.kt
@@ -849,7 +849,9 @@ object Tools {
         return EmojiTheming(
             primaryColor = ColorHelper.getPrimaryColor(context),
             secondaryColor = ColorHelper.getPrimaryTextColor(context),
-            backgroundColor = ColorHelper.getSecondaryColor(context)
+            backgroundColor = ColorHelper.getSecondaryColor(context),
+            textColor = ColorHelper.getPrimaryTextColor(context)
+
         )
     }
 


### PR DESCRIPTION
# Description
Fixed color of emoji search text.

<img src="https://github.com/cloverstudio/SpikaAndroid/assets/46626092/e62e66e5-e2ba-4e92-852d-f793407cdaea" width="50%" height="50%">

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Dev testing.

**Test Configuration**:

* Firmware version: G930FXXS7ETA1
* Hardware: Samsung galaxy s7
* SDK: Android 8, Oreo

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
