### PR TITLE
Stop Carousel Animation

### DIFF
--- a/app/src/main/java/com/clover/studio/spikamessenger/ui/main/chat/media/SmallMediaAdapter.kt
+++ b/app/src/main/java/com/clover/studio/spikamessenger/ui/main/chat/media/SmallMediaAdapter.kt
@@ -59,6 +59,7 @@ class SmallMediaAdapter(
                     val imagePath = Tools.getMediaPath(context, message)
                     Glide.with(context)
                         .load(imagePath)
+                        .dontAnimate()
                         .diskCacheStrategy(DiskCacheStrategy.ALL)
                         .error(AppCompatResources.getDrawable(context, R.drawable.img_media_placeholder_error))
                         .listener(object : RequestListener<Drawable> {


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant
motivation and context. List any dependencies that are required for this change.

Removed animation from small media adapter carousel.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration. All testing was done
manually by following, plainly, functionality requirements. If there are some special edge cases or
special ways that things need to be tested they will be mentioned below.

**Test Configuration**:

* Firmware version: A556BXXS3AXF2
* Hardware: SAMSUNG Galaxy A55
* SDK: Android 14

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
